### PR TITLE
Add branding. Remove duplicate import of bundle script.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Sniffr: The matchmaking site for dogs."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,11 +24,11 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-    <script defer src="/static/js/bundle.js"></script>
+    <title>Sniffr</title>
+    <!-- script defer src="/static/js/bundle.js"></script -- Webpack is adding an extra copy of this line. -->
   </head>
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <noscript>🐶 You need to enable JavaScript to run this app. 🐶</noscript>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Sniffr",
+  "name": "Sniffr",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,16 +7,16 @@ function App() {
     <div className="App">
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
+        <h2>
+        🐶 Welcome to Sniffr! 🐶
+        </h2>
         <a
           className="App-link"
-          href="https://reactjs.org"
+          href="https://github.com/the-best-team-seven/sniffr-fe"
           target="_blank"
           rel="noopener noreferrer"
         >
-          Learn React
+          View the project on GitHub
         </a>
       </header>
     </div>


### PR DESCRIPTION
1. Branding: Changed titles and descriptions.
2.  Remove duplicate script import in `/public/index.html`:

This reverses the change in the last pull request, because...
Webpack merges the html from the `/public` directory with the `/src` directory when it updates the `/build` directory or produces a development build.

Now that Netlify is deploying from the `/build` directory instead of `/public`, it shouldn't be required. You can verify that it is currently added twice by viewing the source at https://team-sniffr.netlify.app/