### PR TITLE
home page css adjustments

### DIFF
--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,6 +1,21 @@
 import { Box, Button, Typography } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import frenchie from './frenchie.jpg';
+import { styled } from '@mui/material/styles';
+
+const HomeDogImage = styled(Box)<any>(({ theme }) => ({
+  borderRadius: '61% 39% 41% 59% / 31% 44% 56% 69%',
+  height: '120vh',
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  zIndex: 1,
+
+  '@media only screen and (max-width: 768px)': {
+    top: 0,
+    left: 0,
+  },
+}));
 
 const HomePage: React.FC = (): React.ReactElement => {
   const navigate = useNavigate();
@@ -39,18 +54,7 @@ const HomePage: React.FC = (): React.ReactElement => {
         </Button>
       </Box>
 
-      <Box
-        component="img"
-        src={frenchie}
-        sx={{
-          borderRadius: '61% 39% 41% 59% / 31% 44% 56% 69%',
-          height: '120vh',
-          position: 'fixed',
-          top: 0,
-          right: 0,
-          zIndex: 1,
-        }}
-      />
+      <HomeDogImage component="img" src={frenchie} />
     </Box>
   );
 };


### PR DESCRIPTION
Adjusted CSS for small / medium screens on homepage. 

Tablet:
<img width="403" alt="Screen Shot 2022-08-18 at 4 50 26 PM" src="https://user-images.githubusercontent.com/48700332/185501763-4a4d2f4e-af59-46a3-9318-d5b7d148b5f4.png">

Mobile:
<img width="390" alt="Screen Shot 2022-08-18 at 4 50 38 PM" src="https://user-images.githubusercontent.com/48700332/185501766-a7663c4a-49ed-4d4e-8121-0f59411407f9.png">
